### PR TITLE
fix: text shadow change sintax

### DIFF
--- a/assets/css/banner/banner-imagem.css
+++ b/assets/css/banner/banner-imagem.css
@@ -1,5 +1,6 @@
 .banner__imagem{
     background: url('/assets/img/banner.jpg') no-repeat center / cover;
+    background-attachment: fixed;
     width: 100%;   
 }
 

--- a/assets/css/banner/banner-titulo.css
+++ b/assets/css/banner/banner-titulo.css
@@ -3,7 +3,7 @@
     font-family: pacifico,cursive;
     position: absolute;
     left: 50%;
-    text-shadow: 0 4px 4px regba(0.0.0.0.75);
+    text-shadow: 0 4px 4px rgba(0,0,0,0.75);
     top: 50%;
     text-align: center;
     transform: translate(-50%, -50%);


### PR DESCRIPTION
A propriedade text-shadow estava com erro de sintax.
- havia "regba" ao invés de "rgba"; e
-  os valores do rgba estavam separados por "." e não por "," que seria o correto.

ps: projeto muito bonito.